### PR TITLE
Fix unmet dependency bug in Kconfig

### DIFF
--- a/kernel/horizon/Kconfig
+++ b/kernel/horizon/Kconfig
@@ -4,5 +4,7 @@ config HORIZON
 	bool "Horizon Linux kernel"
 	depends on ARM64
 	depends on FUTEX
+	depends on !TRANSPARENT_HUGEPAGE
+	select CHECKPOINT_RESTORE
 	select MEM_SOFT_DIRTY
 	default y


### PR DESCRIPTION
When `CONFIG_HORIZON` is enabled in the kernel configuration, it force-enables `CONFIG_MEM_SOFT_DIRTY` without ensuring that its dependencies (`CONFIG_TRANSPARENT_HUGEPAGE=n` and `CONFIG_CHECKPOINT_RESTORE=y`) are satisfied.

The solution: we can safely force-enable `CONFIG_CHECKPOINT_RESTORE` too, but since we cannot force-disable `CONFIG_TRANSPARENT_HUGEPAGE`, we can `depend on` disabling it.

The other option would be to make `CONFIG_HORIZON` use `depends on MEM_SOFT_DIRTY` instead of `select MEM_SOFT_DIRTY`, but this would require more effort on the user's part.